### PR TITLE
Добавлено поле для свежего hscript

### DIFF
--- a/src/halk/macro/HScriptTypedConverter.hx
+++ b/src/halk/macro/HScriptTypedConverter.hx
@@ -339,17 +339,18 @@ class HScriptTypedConverter {
             var res = [];
             for (f in fields) {
                 var name = f.name;
+                var meta = cast(f.meta);
                 switch f.kind {
                     case FVar(t, e):
                         if (e != null) Context.error('default values are not supported in anonymous structs', pos);
-                        res.push({name: name, t: convertComplexType(t, pos)});
+                        res.push({name: name, t: convertComplexType(t, pos), meta: meta});
 
                     case FProp(_, _):
                         Context.error('properties are not supported in anonymous structs', pos);
 
                     case FFun(f):
                         var type = CTFun([for (a in f.args) convertComplexType(a.type, pos)], convertComplexType(f.ret, pos));
-                        res.push({name: name, t: type});
+                        res.push({name: name, t: type, meta: meta});
                 }
             }
             return res;


### PR DESCRIPTION
Без него ругается:
```
C:/HaxeToolkit/haxe/lib/halk/git/src/halk/macro/HScriptTypedConverter.hx:363: characters 44-69 : Array<{ t : hscript.CType, name : String }> should be Array<{ t : hscript.CType, name : String, ?meta : Null<hscript.Metadata> }>
C:/HaxeToolkit/haxe/lib/halk/git/src/halk/macro/HScriptTypedConverter.hx:363: characters 44-69 : Type parameters are invariant
C:/HaxeToolkit/haxe/lib/halk/git/src/halk/macro/HScriptTypedConverter.hx:363: characters 44-69 : { t : hscript.CType, name : String } should be { t : hscript.CType, name : String, ?meta : Null<hscript.Metadata> }
C:/HaxeToolkit/haxe/lib/halk/git/src/halk/macro/HScriptTypedConverter.hx:363: characters 44-69 : { t : hscript.CType, name : String } has no field meta
C:/HaxeToolkit/haxe/lib/halk/git/src/halk/macro/HScriptTypedConverter.hx:363: characters 44-69 : For function argument 'fields'
C:/HaxeToolkit/haxe/lib/halk/git/src/halk/macro/HScriptTypedConverter.hx:363: characters 12-70 : Void should be hscript.CType
C:/HaxeToolkit/haxe/lib/halk/git/src/halk/macro/HScriptTypedConverter.hx:367: characters 23-48 : Array<{ t : hscript.CType, name : String }> should be Array<{ t : hscript.CType, name : String, ?meta : Null<hscript.Metadata> }>
C:/HaxeToolkit/haxe/lib/halk/git/src/halk/macro/HScriptTypedConverter.hx:367: characters 23-48 : Type parameters are invariant
C:/HaxeToolkit/haxe/lib/halk/git/src/halk/macro/HScriptTypedConverter.hx:367: characters 23-48 : { t : hscript.CType, name : String } should be { t : hscript.CType, name : String, ?meta : Null<hscript.Metadata> }
C:/HaxeToolkit/haxe/lib/halk/git/src/halk/macro/HScriptTypedConverter.hx:367: characters 23-48 : { t : hscript.CType, name : String } has no field meta
C:/HaxeToolkit/haxe/lib/halk/git/src/halk/macro/HScriptTypedConverter.hx:367: characters 23-48 : For function argument 'fields'
C:/HaxeToolkit/haxe/lib/halk/git/src/halk/macro/HScriptTypedConverter.hx:365: lines 365-367 : Void should be hscript.CType
Build failure
Build halted with errors.
```